### PR TITLE
fixed stream initialization with int arrays in java streams lecture notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules
 .docusaurus
 build
 /.project
+.idea/
+*.iml

--- a/docs/documentation/introduction.mdx
+++ b/docs/documentation/introduction.mdx
@@ -32,6 +32,11 @@ Discussions) die Studierenden zu eben dieser Zusammenarbeit animieren
 ## Contributors
 
 <Contributor
+  exercisePullRequest="394"
+  userId="61515903"
+  description="fixed stream initialization with int arrays in java streams lecture notes"
+/>
+<Contributor
   exercisePullRequest="93"
   userId="157032921"
   description="Fixed typo in Merge Sort"

--- a/src/pages/slides/steffen/java-2/10-stream-api.tsx
+++ b/src/pages/slides/steffen/java-2/10-stream-api.tsx
@@ -172,6 +172,7 @@ export default function StreamApi(): React.JSX.Element {
           <h2>Erzeugen von Quellen II</h2>
           <pre className="fragment">
             <code
+              data-line-numbers="3-6|8-10|12-13"
               className="java"
               dangerouslySetInnerHTML={{
                 __html:
@@ -179,10 +180,15 @@ export default function StreamApi(): React.JSX.Element {
                   '  public static void main(String[] args) {\n' +
                   '    // Array in ein Stream konvertieren:\n' +
                   '    // Arrays.stream(T[])\n' +
-                  '    Stream&lt;Integer&gt; num1 = Arrays.stream({ 1, 2, 3, 4 });\n' +
+                  '    Stream&lt;Integer&gt; num1 =\n' +
+                  '      Arrays.stream(new Integer[] { 1, 2, 3, 4 });\n' +
                   '    \n' +
+                  '    // Mit .boxed() von int (primitiv) -> Integer (Wrapper)\n' +
                   '    int[] numArray = { 1, 2, 3, 4 };\n' +
-                  '    Stream&lt;Integer&gt; num2 = Arrays.stream(numArray);\n' +
+                  '    Stream&lt;Integer&gt; num2 = Arrays.stream(numArray).boxed();\n' +
+                  '    \n' +
+                  '    // Oder sonst einen IntStream mit int (primitiv)\n' +
+                  '    IntStream num3 = Arrays.stream(new int[] { 1, 2, 3, 4 });\n' +
                   '  }\n' +
                   '}\n',
               }}


### PR DESCRIPTION
Affects https://jappuccini.github.io/java-docs/production/slides/steffen/java-2/10-stream-api#/3/2/0

**Issue**: 

- `Stream<Integer> num1 = Arrays.stream({ 1, 2, 3, 4 })` is not allowed in java.
- Furthermore, `Stream<Integer> num2 = Arrays.stream(numArray)` would return an IntStream and not a generic Stream of _Integer_

**Fixed**: 

- Added in-line Array initialization with type _Integer_: `Stream<Integer> num1 = Arrays.stream(new Integer[] { 1, 2, 3, 4 }`. Note that the Array is an _Integer_ (Wrapper-Class) type array. So the returned stream is a generic stream of type _Integer_.
- Introduced the `IntStream#boxed()` method that returns a _Stream\<Integer\>_ consisting of the elements of this stream, each boxed to the _Integer_ Wrapper-Class.
- Added a third alternative to create a stream from an Array using the _Arrays_ utility class: `IntStream num3 = Arrays.stream(new int[] { 1, 2, 3, 4 });`. Notice here that we used an array of the primitive datatype int, so we get an IntStream instead.
- Added slide animations via the _data-line-numbers_ attribute
- (Also Added some comments) 